### PR TITLE
Add getHostedProfilePageRequest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -804,5 +804,50 @@ module.exports = (function() {
     this.AuthorizeRequest.send('validateCustomerPaymentProfile', xml, xmlOptions, done);
   }
 
+  /**
+    Use this function to initiate a request for direct access to the Authorize.Net website.
+
+    @param {Object} [options={}] An object with options.
+      @param {String|Number} [options.customerProfileId=''] Customer's profile ID.
+      @param {Object|HostedProfileSettings} [options.hostedProfileSettings={}] This is an array of settings for the session (optional).
+        @param {String} [options.hostedProfileSettings.hostedProfileReturnUrl] The URL for the page that the customer returns to when the hosted session ends.
+        @param {String} [options.hostedProfileSettings.hostedProfileReturnUrlText] The text to display on the button that returns the customer to your web site.
+        @param {Boolean} [options.hostedProfileSettings.hostedProfilePageBorderVisible] Enter true or false. Must be false for iframes or popups, and must be true for redirects.
+        @param {String} [options.hostedProfileSettings.hostedProfileHeadingBgColor] A hex color string such as #e0e0e0. The background color of the section headers changes from gray to a custom color.
+        @param {String} [options.hostedProfileSettings.hostedProfileIFrameCommunicatorUrl] This parameter enables you to dynamically change the size of the popup so that there are no scroll bars.
+        @param {String} [options.hostedProfileSettings.hostedProfileValidationMode] Either 'liveMode' or 'testMode'
+        @param {String} [options.hostedProfileSettings.hostedProfileBillingAddressRequired=false] When set to true, results in an asterisk next to the required fields on the hosted form.
+        @param {String} [options.hostedProfileSettings.hostedProfileCardCodeRequired=false] Results in an asterisk next to the card code field on the hosted form.
+    @param {Function} [done=function(){}] Callback function.
+
+    @example
+      AuthorizeNetCIM.getHostedProfilePageRequest({
+        customerProfileId: '123',
+        hostedProfileSettings: {
+          hostedProfileReturnUrl: 'https://example.com/return/',
+          hostedProfileReturnUrlText: 'Continue to confirmation page.',
+          hostedProfilePageBorderVisible: true
+        }
+      }, function(err, response) {})
+  */
+  AuthorizeNetCIM.prototype.getHostedProfilePageRequest = function(options, done) {
+    options = typeof options === "object" ? options : {};
+    options.customerProfileId = options.customerProfileId || '';
+
+    if (arguments.length < 2 || !options.customerProfileId) {
+      throw new Error('You must enter in a customerProfileId.');
+    }
+
+    var hostedProfilePage = new Types.HostedProfilePage(options);
+    var xml = hostedProfilePage.toXml();
+
+    var xmlOptions = {
+      validationMode: options.validationMode
+    };
+
+    this.AuthorizeRequest.send('getHostedProfilePage', xml, xmlOptions, done);
+
+  }
+
   return AuthorizeNetCIM;
 })();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "auth-net-request": "2.2.3",
-    "auth-net-types": "^1.1.0"
+    "auth-net-types": "^1.2.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "auth-net-types": "^1.1.0"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
-    "mocha": "^2.0.1"
+    "chai": "^2.3.0",
+    "mocha": "^2.2.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -430,7 +430,7 @@ describe('AuthorizeNetCIM', function() {
         }, function(err, res) {
           expect(err).to.exist;
           expect(err.code).to.equal('E00040');
-          expect(err.text).to.equal('The record cannot be found.');
+          expect(err.message).to.contain('The record cannot be found.');
           expect(res).to.not.exist;
           done();
         });
@@ -539,7 +539,7 @@ describe('AuthorizeNetCIM', function() {
         }, function(err, res) {
           expect(err).to.exist;
           expect(err.code).to.equal('E00014');
-          expect(err.text).to.equal('Customer Address ID is required.');
+          expect(err.message).to.contain('Customer Address ID is required.');
           expect(res).to.not.exist;
           done();
         });
@@ -951,7 +951,7 @@ describe('AuthorizeNetCIM', function() {
       it('should return an error when we don\'t provide a correct transactionType', function(done) {
         expect(function() {
           AuthorizeCIM.createCustomerProfileTransaction('fake', {}, function(){});
-        }).to.throw(Error, 'Invalid transactionType. Must be: AuthCapture, AuthOnly, CaptureOnly, or PriorAuthCapture');
+        }).to.throw(Error, 'Invalid transactionType. Must be: AuthOnly, AuthCapture, CaptureOnly, PriorAuthCapture, Refund, Void');
         done();
       });
 
@@ -1039,7 +1039,7 @@ describe('AuthorizeNetCIM', function() {
         }, function(err, res) {
           expect(err).to.exist;
           expect(err.code).to.equal('E00027');
-          expect(err.text).to.equal('The specified SplitTenderID is invalid.');
+          expect(err.message).to.contain('The specified SplitTenderID is invalid.');
           expect(res).to.not.exist;
           done();
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -190,7 +190,7 @@ describe('AuthorizeNetCIM', function() {
         };
         request.post(apiUrl, {form: transactionReq} , function(err, response, body) {
           if (err) {
-            console.log('ERROR: ' + err);
+            done(err);
           } else {
             transId = body.split(',')[6];
           }
@@ -1161,7 +1161,6 @@ describe('AuthorizeNetCIM', function() {
         AuthorizeCIM.getHostedProfilePageRequest({
           customerProfileId: 1234,
         }, function(err, res) {
-          console.log(err.toString());
           expect(err).to.exist;
           expect(err.code).to.equal('E00040');
           expect(err.message).to.contain('The record cannot be found.');
@@ -1184,7 +1183,6 @@ describe('AuthorizeNetCIM', function() {
         expect(res.messages.message.text).to.equal('Successful.');
 
         expect(res.token).to.be.an('string');
-        console.log(res.token);
 
         done();
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1047,6 +1047,74 @@ describe('AuthorizeNetCIM', function() {
     });
   });
 
+  describe('#getHostedProfilePageRequest', function () {
+    before(function(done) {
+      var self = this
+        , date = (new Date())
+        , expiration = (date.getFullYear()+1) + '-10'
+        , id = (new Date()).getTime() + Math.floor(Math.random() * (100 - 10 + 1)) + 10;
+
+      AuthorizeCIM.createCustomerProfile({customerProfile: {
+        description: 'A simple description',
+        merchantCustomerId: id,
+        email: 'fakeemail' + id + '@fakemeail.com',
+        paymentProfiles: new Authorize.PaymentProfiles({
+          customerType: 'individual',
+          payment: new Authorize.Payment({
+            creditCard: new Authorize.CreditCard({
+              cardNumber: '4111111111111117',
+              expirationDate: expiration
+            })
+          })
+        })
+      }}, function(err, res) {
+        self.expirationDate = expiration;
+        self.customerProfileId = res.customerProfileId;
+        self.customerPaymentProfileId = res.customerPaymentProfileIdList.numericString;
+        done();
+      });
+    });
+
+    it('should give us an error when we forget to enter in the customerProfileId', function(done) {
+      expect(function() {
+        AuthorizeCIM.getHostedProfilePageRequest(function(){})
+      }).to.throw(Error, 'You must enter in a customerProfileId.');
+      done();
+    });
+
+    it('should return an error message saying the customerProfileId is invalid', function(done) {
+        AuthorizeCIM.getHostedProfilePageRequest({
+          customerProfileId: 1234,
+        }, function(err, res) {
+          console.log(err.toString());
+          expect(err).to.exist;
+          expect(err.code).to.equal('E00040');
+          expect(err.message).to.contain('The record cannot be found.');
+          expect(res).to.not.exist;
+          done();
+        });
+      });
+
+    it('should give us a shipping profile', function(done) {
+      var self = this;
+      AuthorizeCIM.getHostedProfilePageRequest({
+        customerProfileId: this.customerProfileId
+      }, function(err, res) {
+        expect(err).to.not.exist;
+        expect(res).to.exist;
+        expect(res.messages).to.exist;
+        expect(res.messages.message).to.exist;
+        expect(res.messages.resultCode).to.equal('Ok');
+        expect(res.messages.message.code).to.equal('I00001');
+        expect(res.messages.message.text).to.equal('Successful.');
+
+        expect(res.token).to.be.an('string');
+        console.log(res.token);
+
+        done();
+      });
+    });
+  });
 
   describe('#delete', function() {
     describe('#deleteCustomerPaymentProfile', function() {


### PR DESCRIPTION
Closes #11.

Adds functionality to fetch a hosted token using the added `HostedProfilePage` type from durango/authorize-net-types#5.

This feature allows you to fetch a token needed to use hosted forms with AuthorizeNet.

Example usage:

``` javascript
AuthNetCIM.getHostedProfilePageRequest({ customerProfileId: 123 }, function (err, res) {
  if (err) throw err;
  // Access token with res.token
});
```
